### PR TITLE
Feat/JIG48 reset filters

### DIFF
--- a/components/Molecules/Slider/Slider.vue
+++ b/components/Molecules/Slider/Slider.vue
@@ -42,6 +42,14 @@ const dragging = ref<string | null>(null);
 const minPrice = computed(() => Math.min(price1.value, price2.value));
 const maxPrice = computed(() => Math.max(price1.value, price2.value));
 
+watch(
+  () => [props.initialMinPrice, props.initialMaxPrice],
+  ([newMin, newMax]) => {
+    price1.value = newMin;
+    price2.value = newMax;
+  }
+);
+
 const updatePrices = () => {
     emit('update:minPrice', minPrice.value);
     emit('update:maxPrice', maxPrice.value);

--- a/components/Organisms/Filter/Filter.vue
+++ b/components/Organisms/Filter/Filter.vue
@@ -99,6 +99,7 @@
               class="text-underlined"
               type="text"
               @click="resetAllFilters"
+              :class="areFiltersSelected ? 'visible' : 'invisible'"
             >
               <p>{{ t("deleteAllFilters") }}</p>
             </AtomsButtonCTA>
@@ -134,6 +135,22 @@ watch(props, () => {
   filterList.value = props.filters ?? [];
   updateSelectedFilters();
 });
+
+const areFiltersSelected = computed(() => {
+  const hasCheckedFilter = filterCategories.value?.some(
+    (category: {
+      name: string;
+      value: { name: string; checked: boolean }[];
+    }) => {
+      return category.value.some((filter) => filter.checked);
+    }
+  );
+
+  const isPriceRangeSelected =
+    selectedMaxPrice.value !== 5000 || selectedMinPrice.value !== 0;
+  return hasCheckedFilter || isPriceRangeSelected;
+});
+
 function updateSelectedFilters() {
   resetAllFilters();
   if (filterList.value.length) {
@@ -151,7 +168,10 @@ onMounted(async () => {
   let results = await client.searchSingleIndex({
     indexName: FILTERS_COLLECTION,
   });
-  filterCategories.value = results.hits.map((filter: any) => ({
+  const excludeMinMaxFilter = results.hits.filter(
+    (filter: any) => !filter.massimo && !filter.minimo
+  );
+  filterCategories.value = excludeMinMaxFilter.map((filter: any) => ({
     ...filter,
     value: filter.value.map((language: any) => ({
       name: language,

--- a/components/Organisms/Filter/Filter.vue
+++ b/components/Organisms/Filter/Filter.vue
@@ -74,6 +74,7 @@
             <p class="ml-12 mr-6">{{ t("min") }}</p>
             <AtomsInputText
               class="w-20"
+              :key="inputKey"
               v-model="selectedMinPrice"
               :placeholder="''"
               @keydown="validateNumberInput($event)"
@@ -83,6 +84,7 @@
           <div class="flex items-center">
             <p class="ml-12 mr-6">{{ t("max") }}</p>
             <AtomsInputText
+              :key="inputKey + 1"
               class="w-20"
               v-model="selectedMaxPrice"
               :placeholder="''"
@@ -130,6 +132,7 @@ const isOpen = ref(false);
 const selectedMinPrice = ref(0);
 const selectedMaxPrice = ref(5000);
 const selectedFilters = reactive<{ [key: string]: any }>({});
+const inputKey = ref(0);
 
 watch(props, () => {
   filterList.value = props.filters ?? [];
@@ -280,6 +283,7 @@ function resetAllFilters() {
   selectedMinPrice.value = 0;
   selectedMaxPrice.value = 5000;
   selectedFilters["Prezzo"] = { min: 0, max: 5000 };
+  inputKey.value++; //force rerender
 }
 
 watch(isOpen, (newValue) => {

--- a/components/Organisms/FilterWeb/FilterWeb.vue
+++ b/components/Organisms/FilterWeb/FilterWeb.vue
@@ -75,6 +75,7 @@
       <div class="flex mt-4 mb-6 mr-6">
         <AtomsButtonCTA
           class="text-underlined"
+          :class="areFiltersSelected ? 'visible' : 'invisible'"
           type="text"
           @click="resetAllFilters"
         >
@@ -98,7 +99,6 @@ const props = defineProps({
 const filterList = ref<String[]>([]);
 const filterCategories = ref();
 const client = useAlgolia();
-
 const selectedMinPrice = ref(0);
 const selectedMaxPrice = ref(5000);
 const selectedFilters = reactive<{ [key: string]: any }>({});
@@ -106,6 +106,21 @@ const selectedFilters = reactive<{ [key: string]: any }>({});
 watch(props, () => {
   filterList.value = props.filters ?? [];
   updateSelectedFilters();
+});
+
+const areFiltersSelected = computed(() => {
+  const hasCheckedFilter = filterCategories.value?.some(
+    (category: {
+      name: string;
+      value: { name: string; checked: boolean }[];
+    }) => {
+      return category.value.some((filter) => filter.checked);
+    }
+  );
+
+  const isPriceRangeSelected =
+    selectedMaxPrice.value !== 5000 || selectedMinPrice.value !== 0;
+  return hasCheckedFilter || isPriceRangeSelected;
 });
 
 function updateSelectedFilters() {
@@ -125,9 +140,13 @@ onMounted(async () => {
   let results = await client.searchSingleIndex({
     indexName: FILTERS_COLLECTION,
   });
-  filterCategories.value = results.hits.map((filter: any) => ({
+  const excludeMinMaxFilter = results.hits.filter(
+    (filter: any) => !filter.massimo && !filter.minimo
+  );
+
+  filterCategories.value = excludeMinMaxFilter.map((filter: any) => ({
     ...filter,
-    value: filter.value.map((language: any) => ({
+    value: filter.value?.map((language: any) => ({
       name: language,
       checked: false,
     })),

--- a/components/Organisms/FilterWeb/FilterWeb.vue
+++ b/components/Organisms/FilterWeb/FilterWeb.vue
@@ -51,6 +51,7 @@
       <div class="flex items-center my-6">
         <p class="ml-12 mr-6">{{ t("min") }}</p>
         <AtomsInputText
+          :key="inputKey"
           class="w-20"
           v-model="selectedMinPrice"
           :placeholder="''"
@@ -61,6 +62,7 @@
       <div class="flex items-center">
         <p class="ml-12 mr-6">{{ t("max") }}</p>
         <AtomsInputText
+          :key="inputKey + 1"
           class="w-20"
           v-model="selectedMaxPrice"
           :placeholder="''"
@@ -102,6 +104,7 @@ const client = useAlgolia();
 const selectedMinPrice = ref(0);
 const selectedMaxPrice = ref(5000);
 const selectedFilters = reactive<{ [key: string]: any }>({});
+const inputKey = ref(0);
 
 watch(props, () => {
   filterList.value = props.filters ?? [];
@@ -233,6 +236,7 @@ function resetAllFilters() {
   selectedMinPrice.value = 0;
   selectedMaxPrice.value = 5000;
   selectedFilters["Prezzo"] = { min: 0, max: 5000 };
+  inputKey.value++; //force rerender
 }
 </script>
 


### PR DESCRIPTION
# Pull Request Template

## Descrizione delle modifiche

- fixato un bug sui filtri che non ne permetteva il render 
- aggiunta la logica che controlla la visibilità del bottone `Cancella filtri` solo se i filtri sono applicati
- fixato bug sul thumb del range che non ritornava in posizione iniziale quando i filtri venivano resettati
- usato un workaround per svuotare gli input min/max al reset filtri forzando il rerender

## Tipo di cambiamento

- [x] Bug fix (modifiche non invasive che risolvono un problema)
- [x] Nuova funzionalità (modifiche non invasive che aggiungono funzionalità)
- [ ] Breaking change (modifiche che causano cambiamenti sostanziali nel comportamento esistente del software)

